### PR TITLE
feat: 🎸 fix wine-mono installation method (although not in use)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ ARG MONO_VER=6.3.0
 RUN mkdir -p /usr/share/wine/{gecko,mono} \
   && curl -sL -o /usr/share/wine/gecko/wine-gecko-${GECKO_VER}-x86.msi \
     "https://dl.winehq.org/wine/wine-gecko/${GECKO_VER}/wine-gecko-${GECKO_VER}-x86.msi" \
-  # && curl -sL -o /usr/share/wine/mono/wine-mono-${MONO_VER}.msi \
-  #   "https://dl.winehq.org/wine/wine-mono/${MONO_VER}/wine-mono-${MONO_VER}.msi" \
+  # && curl -sL -o /usr/share/wine/mono/wine-mono-${MONO_VER}-x86.msi \
+  #   "https://dl.winehq.org/wine/wine-mono/${MONO_VER}/wine-mono-${MONO_VER}-x86.msi" \
   && chown -R user:group /usr/share/wine/{gecko,mono} \
   && echo 'Gecko & Mono Downloaded' \
   \


### PR DESCRIPTION
Mono URL contains system architecture since 5.0.0.
checkout https://dl.winehq.org/wine/wine-mono/6.4.0/
related issue: #5 